### PR TITLE
Add flags to dependencies

### DIFF
--- a/Formula/curie_dependencies.rb
+++ b/Formula/curie_dependencies.rb
@@ -5,8 +5,8 @@ class CurieDependencies < Formula
   url        "http://api.metacpan.org/source/ZMUGHAL/Renard-Curie-#{stable.version}/META.json", :using => :nounzip
   sha256     '6e6acb2ac2acb5fb44876809ae9f49c21123e8aa878ba237e849bf892fb3a03e'
   homepage   'https://project-renard.github.io/'
-  depends_on 'cpanminus'
-  depends_on 'gtk+3'
+  depends_on 'cpanminus' => :build
+  depends_on 'gtk+3' => ['without-x11']
   depends_on 'gtk-doc'
   depends_on 'clutter-gtk'
   depends_on 'gtk-engines'


### PR DESCRIPTION
- `cpanminus` is only needed for build,
- `gtk+3` should not need X11.

Fixes https://github.com/project-renard/homebrew-project-renard/issues/7.
